### PR TITLE
Document how to symbolise a crash from a stripped package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,17 @@ repository root. To try a build, install the `.eap` on a camera under
 **Apps > Add app** in the device web interface, then check the app log under
 **Apps > (this app) > App log** to confirm it starts.
 
+### Debugging a crash
+
+The packaged binary is stripped, so a crash reports bare addresses. Each build
+also writes the unstripped binary to `debug/`, which CI keeps as the
+`debug-symbols` artifact. Stripping does not move code, so those addresses
+resolve against the unstripped copy:
+
+```sh
+aarch64-linux-gnu-addr2line -f -C -e debug/zerotier-userspace-aarch64.unstripped 0x400b90
+```
+
 ## Pull requests
 
 1. Fork the repository and branch from `main`.


### PR DESCRIPTION
Adds a short Debugging section to CONTRIBUTING.md covering the `debug/` output and the `debug-symbols` CI artifact added alongside binary stripping.

Also serves to exercise the build on a pull request, which builds but never releases, so the new `debug-symbols` upload can be verified.